### PR TITLE
提交丢帧控制相关操作代码

### DIFF
--- a/APIModules/QTSSReflectorModule/ReflectorStream.h
+++ b/APIModules/QTSSReflectorModule/ReflectorStream.h
@@ -278,9 +278,18 @@ class ReflectorSender : public UDPDemuxerTask
     Bool16      GetFirstRTPTimePacket(UInt16* outSeqNumPtr, UInt32* outRTPTimePtr, SInt64* outArrivalTimePtr);
 
     void        RemoveOldPackets(OSQueue* inFreeQueue);
-    OSQueueElem* GetClientBufferStartPacketOffset(SInt64 offsetMsec); 
+    OSQueueElem* GetClientBufferStartPacketOffset(SInt64 offsetMsec,Bool16 needKeyFrameFirstPacket=false); 
     OSQueueElem* GetClientBufferStartPacket() { return this->GetClientBufferStartPacketOffset(0); };
 
+    //->geyijyn@20150427
+    //--重新定位书签位置
+    //<-
+    Bool16 NeedRelocateBookMark(OSQueueElem* currentElem);
+    OSQueueElem* GetNewestKeyFrameFirstPacket(OSQueueElem* currentElem,SInt64 offsetMsec);
+    Bool16 IsKeyFrameFirstPacket(ReflectorPacket* thePacket);
+    Bool16 IsFrameFirstPacket(ReflectorPacket* thePacket);
+    Bool16 IsFrameLastPacket(ReflectorPacket* thePacket);
+	
     ReflectorStream*    fStream;
     UInt32              fWriteFlag;
     
@@ -487,6 +496,8 @@ inline  void                    UpdateBitRate(SInt64 currentTime);
         static UInt32       sBucketDelayInMsec;
         static Bool16       sUsePacketReceiveTime;
         static UInt32       sFirstPacketOffsetMsec;
+
+		static UInt32       sRelocatePacketAgeMSec;	
         
         friend class ReflectorSocket;
         friend class ReflectorSender;

--- a/Server.tproj/RTPStream.cpp
+++ b/Server.tproj/RTPStream.cpp
@@ -1000,7 +1000,13 @@ Bool16 RTPStream::UpdateQualityLevel(const SInt64& inTransmitTime, const SInt64&
     
     if (inTransmitTime <= fSession->GetPlayTime())
         return true;
-                
+
+    //->geyijyn@20150427
+    //---视频流不进行thinning 算法丢帧
+    //<- 
+    if (fPayloadType == qtssVideoPayloadType)
+        return true;           
+
     if (this->Supports3GPPQualityLevels())
         return true;
     


### PR DESCRIPTION
修改1:thinnging算法中有Drop Packet的操作要关闭掉。i
修改2:对于新建的客户端输出，视频数据流直接定位到第一个关键帧起始包，这样出视频的时间会更快一些。
修改3:在每一个客户端output的时候，判断是否需要重新定位书签的位置。
重新设定门限值，ReflectorStream::sRelocatePacketAgeMSec.
即如果output的当前书签的延时时间大于这个门限值,则重新定位书签。