### PR TITLE
support PAUSE method, dropping packets when paused or the length of q…

### DIFF
--- a/rtsp/player.go
+++ b/rtsp/player.go
@@ -3,6 +3,7 @@ package rtsp
 import (
 	"sync"
 	"time"
+	"github.com/penggy/EasyGoLib/utils"
 )
 
 type Player struct {
@@ -10,14 +11,22 @@ type Player struct {
 	Pusher *Pusher
 	cond   *sync.Cond
 	queue  []*RTPPack
+	queueLimit int
+	dropPacketWhenPaused bool
+	paused bool
 }
 
 func NewPlayer(session *Session, pusher *Pusher) (player *Player) {
+	queueLimit := utils.Conf().Section("rtsp").Key("player_queue_limit").MustInt(0)
+	dropPacketWhenPaused := utils.Conf().Section("rtsp").Key("drop_packet_when_paused").MustInt(0)
 	player = &Player{
 		Session: session,
 		Pusher:  pusher,
 		cond:    sync.NewCond(&sync.Mutex{}),
 		queue:   make([]*RTPPack, 0),
+		queueLimit: queueLimit,
+		dropPacketWhenPaused: dropPacketWhenPaused != 0,
+		paused:  false,
 	}
 	session.StopHandles = append(session.StopHandles, func() {
 		pusher.RemovePlayer(player)
@@ -32,8 +41,18 @@ func (player *Player) QueueRTP(pack *RTPPack) *Player {
 		logger.Printf("player queue enter nil pack, drop it")
 		return player
 	}
+	if player.paused && player.dropPacketWhenPaused {
+		return player
+	}
 	player.cond.L.Lock()
 	player.queue = append(player.queue, pack)
+	if oldLen := len(player.queue); player.queueLimit > 0 && oldLen > player.queueLimit {
+		player.queue = player.queue[1:]
+		if player.debugLogEnable {
+			len := len(player.queue)
+			logger.Printf("Player %s, QueueRTP, exceeds limit(%d), drop %d old packets, current queue.len=%d\n", player.String(), player.queueLimit, oldLen - len, len)
+		}
+	}
 	player.cond.Signal()
 	player.cond.L.Unlock()
 	return player
@@ -52,7 +71,11 @@ func (player *Player) Start() {
 			pack = player.queue[0]
 			player.queue = player.queue[1:]
 		}
+		queueLen := len(player.queue)
 		player.cond.L.Unlock()
+		if player.paused {
+			continue
+		}
 		if pack == nil {
 			if !player.Stoped {
 				logger.Printf("player not stoped, but queue take out nil pack")
@@ -63,9 +86,23 @@ func (player *Player) Start() {
 			logger.Println(err)
 		}
 		elapsed := time.Now().Sub(timer)
-		if elapsed >= 30*time.Second {
-			logger.Printf("Send a package.type:%d\n", pack.Type)
+		if player.debugLogEnable && elapsed >= 30*time.Second {
+			logger.Printf("Player %s, Send a package.type:%d, queue.len=%d\n", player.String(), pack.Type, queueLen)
 			timer = time.Now()
 		}
 	}
+}
+
+func (player *Player) Pause(paused bool) {
+	if paused {
+		player.logger.Printf("Player %s, Pause\n", player.String())
+	} else {
+		player.logger.Printf("Player %s, Play\n", player.String())
+	}
+	player.cond.L.Lock()
+	if paused && player.dropPacketWhenPaused && len(player.queue) > 0 {
+		player.queue = make([]*RTPPack, 0)
+	}
+	player.paused = paused
+	player.cond.L.Unlock()
 }

--- a/rtsp/pusher.go
+++ b/rtsp/pusher.go
@@ -311,6 +311,13 @@ func (pusher *Pusher) GetPlayers() (players map[string]*Player) {
 	return
 }
 
+func (pusher *Pusher) HasPlayer(player *Player) bool {
+	pusher.playersLock.Lock()
+	_, ok := pusher.players[player.ID]
+	pusher.playersLock.Unlock()
+	return ok
+}
+
 func (pusher *Pusher) AddPlayer(player *Player) *Pusher {
 	logger := pusher.Logger()
 	if pusher.gopCacheEnable {

--- a/rtsp/rtsp-client.go
+++ b/rtsp/rtsp-client.go
@@ -48,6 +48,9 @@ type RTSPClient struct {
 	OptionIntervalMillis int64
 	SDPRaw               string
 
+	debugLogEnable       bool
+	lastRtpSN            uint16
+
 	Agent    string
 	authLine string
 
@@ -71,6 +74,7 @@ func NewRTSPClient(server *Server, rawUrl string, sendOptionMillis int64, agent 
 	if err != nil {
 		return
 	}
+	debugLogEnable := utils.Conf().Section("rtsp").Key("debug_log_enable").MustInt(0)
 	client = &RTSPClient{
 		Server:               server,
 		Stoped:               false,
@@ -85,6 +89,7 @@ func NewRTSPClient(server *Server, rawUrl string, sendOptionMillis int64, agent 
 		OptionIntervalMillis: sendOptionMillis,
 		StartAt:              time.Now(),
 		Agent:                agent,
+		debugLogEnable:       debugLogEnable != 0,
 	}
 	client.logger = log.New(os.Stdout, fmt.Sprintf("[%s]", client.ID), log.LstdFlags|log.Lshortfile)
 	if !utils.Debug {
@@ -417,11 +422,24 @@ func (client *RTSPClient) startStream() {
 				client.logger.Printf("session tcp got nil rtp pack")
 				continue
 			}
-			elapsed := time.Now().Sub(loggerTime)
-			if elapsed >= 10*time.Second {
-				client.logger.Printf("%v read rtp frame.", client)
-				loggerTime = time.Now()
+
+			if client.debugLogEnable {
+				rtp := ParseRTP(pack.Buffer.Bytes())
+				if rtp != nil {
+					rtpSN := uint16(rtp.SequenceNumber)
+					if client.lastRtpSN != 0 && client.lastRtpSN + 1 != rtpSN {
+						client.logger.Printf("%s, %d packets lost, current SN=%d, last SN=%d\n", client.String(), rtpSN - client.lastRtpSN, rtpSN, client.lastRtpSN)
+					}
+					client.lastRtpSN = rtpSN
+				}
+
+				elapsed := time.Now().Sub(loggerTime)
+				if elapsed >= 30*time.Second {
+					client.logger.Printf("%v read rtp frame.", client)
+					loggerTime = time.Now()
+				}
 			}
+
 			client.InBytes += int(length + 4)
 			for _, h := range client.RTPHandles {
 				h(pack)


### PR DESCRIPTION
主要改动：
1. player增加暂停机制，暂停模式下可以选择不向客户端发送RTP包或者直接将RTP包丢弃（通过配置drop_packet_when_paused进行控制）
2. 增加配置player_queue_limit，对player的RTP队列长度进行限制（默认为0表示不限制），超过长度将RTP包丢弃，避免因客户端问题导致服务器内存增长
3. 增加debug_log_enable开关，将收发数据的日志输出放到此开关下，避免无用日志太多，同时pusher增加RTP丢包检测