### PR TITLE
修复"Pull stream err: EOF"

### DIFF
--- a/rtsp/rtsp-client.go
+++ b/rtsp/rtsp-client.go
@@ -639,7 +639,7 @@ func (client *RTSPClient) RequestWithPath(method string, path string, headers ma
 		//		return
 		//	}
 		//}
-		if strings.Index(s, "Content-Length:") == 0 {
+		if strings.Index(strings.ToLower(s), "content-length:") == 0 {
 			splits := strings.Split(s, ":")
 			contentLen, err = strconv.Atoi(strings.TrimSpace(splits[1]))
 			if err != nil {


### PR DESCRIPTION
Fixes #130 有的设备返回的数据中`Content-Length`写成`Content-length`导致无法识别`body`长度，以致`resp.body`为空，故改成忽略大小写