### PR TITLE
解决关于err返回值的bug

### DIFF
--- a/rtsp/rtsp-client.go
+++ b/rtsp/rtsp-client.go
@@ -660,8 +660,10 @@ func (client *RTSPClient) Request(method string, headers map[string]string) (*Re
 }
 
 func (client *RTSPClient) RequestNoResp(method string, headers map[string]string) (err error) {
-	l, err := url.Parse(client.URL)
-	if err != nil {
+	var (
+		l *url.URL
+	)
+	if l, err = url.Parse(client.URL); err != nil {
 		return fmt.Errorf("Url parse error:%v", err)
 	}
 	l.User = nil

--- a/rtsp/rtsp-server.go
+++ b/rtsp/rtsp-server.go
@@ -41,13 +41,15 @@ func GetServer() *Server {
 }
 
 func (server *Server) Start() (err error) {
-	logger := server.logger
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", server.TCPPort))
-	if err != nil {
+	var (
+		logger   = server.logger
+		addr     *net.TCPAddr
+		listener *net.TCPListener
+	)
+	if addr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", server.TCPPort)); err != nil {
 		return
 	}
-	listener, err := net.ListenTCP("tcp", addr)
-	if err != nil {
+	if listener, err = net.ListenTCP("tcp", addr); err != nil {
 		return
 	}
 
@@ -57,7 +59,7 @@ func (server *Server) Start() (err error) {
 	ts_duration_second := utils.Conf().Section("rtsp").Key("ts_duration_second").MustInt(6)
 	SaveStreamToLocal := false
 	if (len(ffmpeg) > 0) && localRecord > 0 && len(m3u8_dir_path) > 0 {
-		err := utils.EnsureDir(m3u8_dir_path)
+		err = utils.EnsureDir(m3u8_dir_path)
 		if err != nil {
 			logger.Printf("Create m3u8_dir_path[%s] err:%v.", m3u8_dir_path, err)
 		} else {
@@ -151,16 +153,18 @@ func (server *Server) Start() (err error) {
 	logger.Println("rtsp server start on", server.TCPPort)
 	networkBuffer := utils.Conf().Section("rtsp").Key("network_buffer").MustInt(1048576)
 	for !server.Stoped {
-		conn, err := server.TCPListener.Accept()
-		if err != nil {
+		var (
+			conn net.Conn
+		)
+		if conn, err = server.TCPListener.Accept(); err != nil {
 			logger.Println(err)
 			continue
 		}
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			if err := tcpConn.SetReadBuffer(networkBuffer); err != nil {
+			if err = tcpConn.SetReadBuffer(networkBuffer); err != nil {
 				logger.Printf("rtsp server conn set read buffer error, %v", err)
 			}
-			if err := tcpConn.SetWriteBuffer(networkBuffer); err != nil {
+			if err = tcpConn.SetWriteBuffer(networkBuffer); err != nil {
 				logger.Printf("rtsp server conn set write buffer error, %v", err)
 			}
 		}

--- a/rtsp/udp-client.go
+++ b/rtsp/udp-client.go
@@ -92,7 +92,10 @@ func (c *UDPClient) SetupAudio() (err error) {
 }
 
 func (c *UDPClient) SetupVideo() (err error) {
-	logger := c.logger
+	var (
+		logger = c.logger
+		addr   *net.UDPAddr
+	)
 	defer func() {
 		if err != nil {
 			logger.Println(err)
@@ -101,19 +104,17 @@ func (c *UDPClient) SetupVideo() (err error) {
 	}()
 	host := c.Conn.RemoteAddr().String()
 	host = host[:strings.LastIndex(host, ":")]
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, c.VPort))
-	if err != nil {
+	if addr, err = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, c.VPort)); err != nil {
 		return
 	}
-	c.VConn, err = net.DialUDP("udp", nil, addr)
-	if err != nil {
+	if c.VConn, err = net.DialUDP("udp", nil, addr); err != nil {
 		return
 	}
 	networkBuffer := utils.Conf().Section("rtsp").Key("network_buffer").MustInt(1048576)
-	if err := c.VConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = c.VConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client video conn set read buffer error, %v", err)
 	}
-	if err := c.VConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = c.VConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client video conn set write buffer error, %v", err)
 	}
 
@@ -125,10 +126,10 @@ func (c *UDPClient) SetupVideo() (err error) {
 	if err != nil {
 		return
 	}
-	if err := c.VControlConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = c.VControlConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client video control conn set read buffer error, %v", err)
 	}
-	if err := c.VControlConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = c.VControlConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client video control conn set write buffer error, %v", err)
 	}
 	return
@@ -157,8 +158,8 @@ func (c *UDPClient) SendRTP(pack *RTPPack) (err error) {
 		err = fmt.Errorf("udp client send rtp pack type[%v] failed, conn not found", pack.Type)
 		return
 	}
-	n, err := conn.Write(pack.Buffer.Bytes())
-	if err != nil {
+	var n int
+	if n, err = conn.Write(pack.Buffer.Bytes()); err != nil {
 		err = fmt.Errorf("udp client write bytes error, %v", err)
 		return
 	}

--- a/rtsp/udp-client.go
+++ b/rtsp/udp-client.go
@@ -47,7 +47,10 @@ func (s *UDPClient) Stop() {
 }
 
 func (c *UDPClient) SetupAudio() (err error) {
-	logger := c.logger
+	var (
+		logger = c.logger
+		addr   *net.UDPAddr
+	)
 	defer func() {
 		if err != nil {
 			logger.Println(err)
@@ -56,8 +59,7 @@ func (c *UDPClient) SetupAudio() (err error) {
 	}()
 	host := c.Conn.RemoteAddr().String()
 	host = host[:strings.LastIndex(host, ":")]
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, c.APort))
-	if err != nil {
+	if addr, err = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, c.APort)); err != nil {
 		return
 	}
 	c.AConn, err = net.DialUDP("udp", nil, addr)
@@ -65,10 +67,10 @@ func (c *UDPClient) SetupAudio() (err error) {
 		return
 	}
 	networkBuffer := utils.Conf().Section("rtsp").Key("network_buffer").MustInt(1048576)
-	if err := c.AConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = c.AConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client audio conn set read buffer error, %v", err)
 	}
-	if err := c.AConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = c.AConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client audio conn set write buffer error, %v", err)
 	}
 
@@ -80,10 +82,10 @@ func (c *UDPClient) SetupAudio() (err error) {
 	if err != nil {
 		return
 	}
-	if err := c.AControlConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = c.AControlConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client audio control conn set read buffer error, %v", err)
 	}
-	if err := c.AControlConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = c.AControlConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp client audio control conn set write buffer error, %v", err)
 	}
 	return

--- a/rtsp/udp-server.go
+++ b/rtsp/udp-server.go
@@ -91,20 +91,21 @@ func (s *UDPServer) Stop() {
 }
 
 func (s *UDPServer) SetupAudio() (err error) {
-	logger := s.Logger()
-	addr, err := net.ResolveUDPAddr("udp", ":0")
-	if err != nil {
+	var (
+		logger = s.Logger()
+		addr   *net.UDPAddr
+	)
+	if addr, err = net.ResolveUDPAddr("udp", ":0"); err != nil {
 		return
 	}
-	s.AConn, err = net.ListenUDP("udp", addr)
-	if err != nil {
+	if s.AConn, err = net.ListenUDP("udp", addr); err != nil {
 		return
 	}
 	networkBuffer := utils.Conf().Section("rtsp").Key("network_buffer").MustInt(1048576)
-	if err := s.AConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = s.AConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server audio conn set read buffer error, %v", err)
 	}
-	if err := s.AConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = s.AConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server audio conn set write buffer error, %v", err)
 	}
 	la := s.AConn.LocalAddr().String()
@@ -147,10 +148,10 @@ func (s *UDPServer) SetupAudio() (err error) {
 	if err != nil {
 		return
 	}
-	if err := s.AControlConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = s.AControlConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server audio control conn set read buffer error, %v", err)
 	}
-	if err := s.AControlConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = s.AControlConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server audio control conn set write buffer error, %v", err)
 	}
 	la = s.AControlConn.LocalAddr().String()
@@ -184,8 +185,11 @@ func (s *UDPServer) SetupAudio() (err error) {
 }
 
 func (s *UDPServer) SetupVideo() (err error) {
-	logger := s.Logger()
-	addr, err := net.ResolveUDPAddr("udp", ":0")
+	var (
+		logger = s.Logger()
+		addr   *net.UDPAddr
+	)
+	addr, err = net.ResolveUDPAddr("udp", ":0")
 	if err != nil {
 		return
 	}
@@ -194,10 +198,10 @@ func (s *UDPServer) SetupVideo() (err error) {
 		return
 	}
 	networkBuffer := utils.Conf().Section("rtsp").Key("network_buffer").MustInt(1048576)
-	if err := s.VConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = s.VConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server video conn set read buffer error, %v", err)
 	}
-	if err := s.VConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = s.VConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server video conn set write buffer error, %v", err)
 	}
 	la := s.VConn.LocalAddr().String()
@@ -212,7 +216,8 @@ func (s *UDPServer) SetupVideo() (err error) {
 		defer logger.Printf("udp server stop listen video port[%d]", s.VPort)
 		timer := time.Unix(0, 0)
 		for !s.Stoped {
-			if n, _, err := s.VConn.ReadFromUDP(bufUDP); err == nil {
+			var n int
+			if n, _, err = s.VConn.ReadFromUDP(bufUDP); err == nil {
 				elapsed := time.Now().Sub(timer)
 				if elapsed >= 30*time.Second {
 					logger.Printf("Package recv from VConn.len:%d\n", n)
@@ -241,10 +246,10 @@ func (s *UDPServer) SetupVideo() (err error) {
 	if err != nil {
 		return
 	}
-	if err := s.VControlConn.SetReadBuffer(networkBuffer); err != nil {
+	if err = s.VControlConn.SetReadBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server video control conn set read buffer error, %v", err)
 	}
-	if err := s.VControlConn.SetWriteBuffer(networkBuffer); err != nil {
+	if err = s.VControlConn.SetWriteBuffer(networkBuffer); err != nil {
 		logger.Printf("udp server video control conn set write buffer error, %v", err)
 	}
 	la = s.VControlConn.LocalAddr().String()
@@ -258,7 +263,8 @@ func (s *UDPServer) SetupVideo() (err error) {
 		logger.Printf("udp server start listen video control port[%d]", s.VControlPort)
 		defer logger.Printf("udp server stop listen video control port[%d]", s.VControlPort)
 		for !s.Stoped {
-			if n, _, err := s.VControlConn.ReadFromUDP(bufUDP); err == nil {
+			var n int
+			if n, _, err = s.VControlConn.ReadFromUDP(bufUDP); err == nil {
 				//logger.Printf("Package recv from VControlConn.len:%d\n", n)
 				rtpBytes := make([]byte, n)
 				s.AddInputBytes(n)


### PR DESCRIPTION
当函数返回值为(err error)时，err := xx 导致的结果是err是代码块内部的变量 并没有赋值给err返回值