### PR TITLE
FIX utils.Conf() would not read easy-darwin.ini configuration 

### DIFF
--- a/routers/stats.go
+++ b/routers/stats.go
@@ -49,7 +49,7 @@ func (h *APIHandler) Pushers(c *gin.Context) {
 	}
 	hostname := utils.GetRequestHostname(c.Request)
 	pushers := make([]interface{}, 0)
-	for _, pusher := range rtsp.Instance.GetPushers() {
+	for _, pusher := range rtsp.GetServer().GetPushers() {
 		port := pusher.Server().TCPPort
 		rtsp := fmt.Sprintf("rtsp://%s:%d%s", hostname, port, pusher.Path())
 		if port == 554 {
@@ -102,7 +102,7 @@ func (h *APIHandler) Players(c *gin.Context) {
 		return
 	}
 	players := make([]*rtsp.Player, 0)
-	for _, pusher := range rtsp.Instance.GetPushers() {
+	for _, pusher := range rtsp.GetServer().GetPushers() {
 		for _, player := range pusher.GetPlayers() {
 			players = append(players, player)
 		}

--- a/routers/sys.go
+++ b/routers/sys.go
@@ -50,9 +50,9 @@ func init() {
 				now := utils.DateTime(time.Now())
 				memData = append(memData, PercentData{Time: now, Used: mem.UsedPercent / 100})
 				cpuData = append(cpuData, PercentData{Time: now, Used: cpu[0] / 100})
-				pusherData = append(pusherData, CountData{Time: now, Total: uint(rtsp.Instance.GetPusherSize())})
+				pusherData = append(pusherData, CountData{Time: now, Total: uint(rtsp.GetServer().GetPusherSize())})
 				playerCnt := 0
-				for _, pusher := range rtsp.Instance.GetPushers() {
+				for _, pusher := range rtsp.GetServer().GetPushers() {
 					playerCnt += len(pusher.GetPlayers())
 				}
 				playerData = append(playerData, CountData{Time: now, Total: uint(playerCnt)})

--- a/rtsp/rtsp-server.go
+++ b/rtsp/rtsp-server.go
@@ -27,17 +27,23 @@ type Server struct {
 	removePusherCh chan *Pusher
 }
 
-var Instance *Server = &Server{
-	SessionLogger:  SessionLogger{log.New(os.Stdout, "[RTSPServer]", log.LstdFlags|log.Lshortfile)},
-	Stoped:         true,
-	TCPPort:        utils.Conf().Section("rtsp").Key("port").MustInt(554),
-	pushers:        make(map[string]*Pusher),
-	addPusherCh:    make(chan *Pusher),
-	removePusherCh: make(chan *Pusher),
-}
+var (
+	instance *Server
+	once sync.Once
+)
 
 func GetServer() *Server {
-	return Instance
+	once.Do(func() {
+		instance = &Server{
+			SessionLogger:  SessionLogger{log.New(os.Stdout, "[RTSPServer]", log.LstdFlags|log.Lshortfile)},
+			Stoped:         true,
+			TCPPort:        utils.Conf().Section("rtsp").Key("port").MustInt(554),
+			pushers:        make(map[string]*Pusher),
+			addPusherCh:    make(chan *Pusher),
+			removePusherCh: make(chan *Pusher),
+		}
+	})
+	return instance
 }
 
 func (server *Server) Start() (err error) {


### PR DESCRIPTION
由于Server类型的初始化是全局初始化，如下代码。
```go
var Instance *Server = &Server{
      SessionLogger:  SessionLogger{log.New(os.Stdout, "[RTSPServer]", log.LstdFlags|log.Lshortfile)},
       Stoped:         true,
       TCPPort:        utils.Conf().Section("rtsp").Key("port").MustInt(554),
       pushers:        make(map[string]*Pusher),
       addPusherCh:    make(chan *Pusher),
       removePusherCh: make(chan *Pusher),
}
```
其中TCPPort读取了utils.Conf()，此时main函数中的`FlagVarConfFile`尚未初始化，这将导致utils.Conf()使用init包内置的配置将`conf`变量初始化，当main函数初始化时候，这边已经不会再次初始化了，因为conf已经初始化了。

```go
func Conf() *ini.File {
	if conf != nil {
		return conf
	}
	if _conf, err := ini.InsensitiveLoad(ConfFile()); err != nil {
		_conf, _ = ini.LoadSources(ini.LoadOptions{Insensitive: true}, []byte(""))
		conf = _conf
	} else {
		conf = _conf
	}
	return conf
}
```

此外，修改所有调用方，使用`GetServer()`方法获取对象，并使用double check来完成单例的初始化。


